### PR TITLE
Add scripts redirect for v0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -253,6 +253,23 @@ update_script() {
     exit 0
 }
 
+install_agent_v0() {
+    shell_url="https://raw.githubusercontent.com/nezhahq/scripts/refs/heads/v0/install.sh"
+    file_name="nezha_v0.sh"
+    if command -v wget >/dev/null 2>&1; then
+        wget -O "/tmp/install_v0.sh" "$shell_url"
+    elif command -v curl >/dev/null 2>&1; then
+        curl -o "/tmp/install_v0.sh" "$shell_url"
+    fi
+    chmod a+x /tmp/install_v0.sh
+    mv -f /tmp/install_v0.sh ./nezha_v0.sh
+    echo "3s后执行新脚本"
+    sleep 3s
+    clear
+    exec ./nezha_v0.sh "$@"
+    exit 0
+}
+
 before_show_menu() {
     echo && info "* 按回车返回主菜单 *" && read temp
     show_menu
@@ -607,6 +624,9 @@ if [ $# -gt 0 ]; then
             ;;
         "update_script")
             update_script 0
+            ;;
+        "install_agent")
+            install_agent_v0 "$@"
             ;;
         *) show_usage ;;
     esac

--- a/install_en.sh
+++ b/install_en.sh
@@ -253,6 +253,23 @@ update_script() {
     exit 0
 }
 
+install_agent_v0() {
+    shell_url="https://raw.githubusercontent.com/nezhahq/scripts/refs/heads/v0/install.sh"
+    file_name="nezha_v0.sh"
+    if command -v wget >/dev/null 2>&1; then
+        wget -O "/tmp/install_v0.sh" "$shell_url"
+    elif command -v curl >/dev/null 2>&1; then
+        curl -o "/tmp/install_v0.sh" "$shell_url"
+    fi
+    chmod a+x /tmp/install_v0.sh
+    mv -f /tmp/install_v0.sh ./nezha_v0.sh
+    echo "Execute new script after 3s"
+    sleep 3s
+    clear
+    exec ./nezha_v0.sh "$@"
+    exit 0
+}
+
 before_show_menu() {
     echo && info "* Press Enter to return to the main menu *" && read temp
     show_menu
@@ -607,6 +624,9 @@ if [ $# -gt 0 ]; then
             ;;
         "update_script")
             update_script 0
+            ;;
+        "install_agent")
+            install_agent_v0 "$@"
             ;;
         *) show_usage ;;
     esac

--- a/nezha/template.sh
+++ b/nezha/template.sh
@@ -253,6 +253,23 @@ update_script() {
     exit 0
 }
 
+install_agent_v0() {
+    shell_url="https://raw.githubusercontent.com/nezhahq/scripts/refs/heads/v0/install.sh"
+    file_name="nezha_v0.sh"
+    if command -v wget >/dev/null 2>&1; then
+        wget -O "/tmp/install_v0.sh" "$shell_url"
+    elif command -v curl >/dev/null 2>&1; then
+        curl -o "/tmp/install_v0.sh" "$shell_url"
+    fi
+    chmod a+x /tmp/install_v0.sh
+    mv -f /tmp/install_v0.sh ./nezha_v0.sh
+    echo _("Execute new script after 3s")
+    sleep 3s
+    clear
+    exec ./nezha_v0.sh "$@"
+    exit 0
+}
+
 before_show_menu() {
     echo && info _("* Press Enter to return to the main menu *") && read temp
     show_menu
@@ -607,6 +624,9 @@ if [ $# -gt 0 ]; then
             ;;
         "update_script")
             update_script 0
+            ;;
+        "install_agent")
+            install_agent_v0 "$@"
             ;;
         *) show_usage ;;
     esac


### PR DESCRIPTION
v1 的 install 脚本中无 install_agent 参数，只有 v0 面板生成的一键安装会用到。
当 install_agent 参数存在时，重定向至 v0 的安装脚本，保证 v0 Linux 一键安装能力可用。