### PR TITLE
Fix openwrt wget fail

### DIFF
--- a/agent/install.sh
+++ b/agent/install.sh
@@ -141,7 +141,7 @@ install() {
         NZ_AGENT_URL="https://${GITHUB_URL}/naibahq/agent/releases/download/${_version}/nezha-agent_${os}_${os_arch}.zip"
     fi
 
-    _cmd="wget -t 2 -T 60 -O /tmp/nezha-agent_${os}_${os_arch}.zip $NZ_AGENT_URL >/dev/null 2>&1"
+    _cmd="wget -T 60 -O /tmp/nezha-agent_${os}_${os_arch}.zip $NZ_AGENT_URL >/dev/null 2>&1"
     if ! eval "$_cmd"; then
         err "Download nezha-agent release failed, check your network connectivity"
         exit 1


### PR DESCRIPTION
OpenWrt uses BusyBox version of wget, which doesn't support -t. Also, we don't really need `-t` to retry twice for downloading.
