### PR TITLE
feat(agent/install.sh): Add LoongArch64 support

### DIFF
--- a/agent/install.sh
+++ b/agent/install.sh
@@ -95,6 +95,9 @@ env_check() {
         mipsel|mipsle)
             os_arch="mipsle"
             ;;
+        loongarch64)
+            os_arch="loong64"
+            ;;
         *)
             err "Unknown architecture: $mach"
             exit 1


### PR DESCRIPTION
This pr follows https://github.com/nezhahq/agent/pull/224

[LoongArch64](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC like ISA developed by Loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it and it is already become a [offically supported architecture](https://lists.debian.org/debian-devel-announce/2025/12/msg00004.html) in the Debian project.

The following information may be useful:

- The output of `uname -m` on a LoongArch64 machine running Debian:

  ```shell
  elysia@elysia-loongson:~ (master =)$ uname -m
  loongarch64
  ```

- Go 1.19 adds support for the Loongson 64-bit architecture [LoongArch](https://loongson.github.io/LoongArch-Documentation) on Linux (GOOS=linux, GOARCH=loong64). The implemented ABI is LP64D. Minimum kernel version supported is 5.19.
